### PR TITLE
powerlaw 1.4.6 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7f9d9cb39ad23af8f6cae165d47020ee8b7fa58f380c356de91ae2625577699e
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -25,6 +25,7 @@ requirements:
     - numpy
     - python
     - scipy
+
 test:
   imports:
     - powerlaw


### PR DESCRIPTION
powerlaw 1.4.6 

**Destination channel:** Defaults

### Links

- [PKG-8217]
- dev_url:        https://github.com/jeffalstott/powerlaw/tree/master
- conda_forge:    https://github.com/conda-forge/powerlaw-feedstock
- pypi:           https://pypi.org/project/powerlaw/1.4.6
- pypi inspector: https://inspector.pypi.io/project/powerlaw/1.4.6

### Explanation of changes:

- bump build number

This rebuild will change the implied `numpy` pinning from `<2` to allow `>=2`.

The only downstreams are `cornac` (which requires this change) and `scikit-mobility` (in SF) where the downstream tests fall over with the existing version... "got an unexpected keyword argument" 🤷 

[PKG-8217]: https://anaconda.atlassian.net/browse/PKG-8217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ